### PR TITLE
Fix chart download to only capture front face

### DIFF
--- a/src/components/widgets/WidgetHeader.tsx
+++ b/src/components/widgets/WidgetHeader.tsx
@@ -147,19 +147,29 @@ export const WidgetHeader = ({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
-              onSelect={(e) => {
+              onSelect={async (e) => {
                 stop(e);
                 const el = document.getElementById(`widget-${widgetId}`);
-                if (el) downloadElementAsPDF(el, `${title}.pdf`);
+                if (!el) return;
+                const back = el.querySelector('[data-face="back"]') as HTMLElement | null;
+                const prevDisplay = back?.style.display;
+                if (back) back.style.display = 'none';
+                await downloadElementAsPDF(el, `${title}.pdf`);
+                if (back) back.style.display = prevDisplay || '';
               }}
             >
               Download PDF
             </DropdownMenuItem>
             <DropdownMenuItem
-              onSelect={(e) => {
+              onSelect={async (e) => {
                 stop(e);
                 const el = document.getElementById(`widget-${widgetId}`);
-                if (el) downloadElementAsJPEG(el, `${title}.jpeg`);
+                if (!el) return;
+                const back = el.querySelector('[data-face="back"]') as HTMLElement | null;
+                const prevDisplay = back?.style.display;
+                if (back) back.style.display = 'none';
+                await downloadElementAsJPEG(el, `${title}.jpeg`);
+                if (back) back.style.display = prevDisplay || '';
               }}
             >
               Download JPEG

--- a/src/components/widgets/WidgetWrapper.tsx
+++ b/src/components/widgets/WidgetWrapper.tsx
@@ -91,6 +91,7 @@ export const WidgetWrapper = ({ widgetId, title, className }: WidgetWrapperProps
         {/* Front (chart) */}
         <div
           className="absolute inset-0"
+          data-face="front"
           style={{ backfaceVisibility: 'hidden', WebkitBackfaceVisibility: 'hidden' }}
         >
           <div className="p-2 h-full">
@@ -101,6 +102,7 @@ export const WidgetWrapper = ({ widgetId, title, className }: WidgetWrapperProps
         {/* Back (table / SQL) */}
         <div
           className="absolute inset-0"
+          data-face="back"
           style={{
             backfaceVisibility: 'hidden',
             WebkitBackfaceVisibility: 'hidden',


### PR DESCRIPTION
## Summary
- tag front and back faces in WidgetWrapper
- hide back face when downloading PDF/JPEG so only the chart face is captured

## Testing
- `npm run build`
- `npm run lint` *(fails: 11 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688900bc11b48324a4a0fc8bc70021fb