### PR TITLE
Fix chart download to capture full widget

### DIFF
--- a/src/components/widgets/WidgetHeader.tsx
+++ b/src/components/widgets/WidgetHeader.tsx
@@ -147,19 +147,37 @@ export const WidgetHeader = ({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
-              onSelect={(e) => {
+              onSelect={async (e) => {
                 stop(e);
                 const el = document.getElementById(`widget-${widgetId}`);
-                if (el) downloadElementAsPDF(el, `${title}.pdf`);
+                if (!el) return;
+                const back = el.querySelector('[data-face="back"]') as HTMLElement | null;
+                const rotator = el.querySelector('[data-rotator]') as HTMLElement | null;
+                const prevDisplay = back?.style.display;
+                const prevTransform = rotator?.style.transform;
+                if (back) back.style.display = 'none';
+                if (rotator) rotator.style.transform = 'none';
+                await downloadElementAsPDF(el, `${title}.pdf`);
+                if (back) back.style.display = prevDisplay || '';
+                if (rotator) rotator.style.transform = prevTransform || '';
               }}
             >
               Download PDF
             </DropdownMenuItem>
             <DropdownMenuItem
-              onSelect={(e) => {
+              onSelect={async (e) => {
                 stop(e);
                 const el = document.getElementById(`widget-${widgetId}`);
-                if (el) downloadElementAsJPEG(el, `${title}.jpeg`);
+                if (!el) return;
+                const back = el.querySelector('[data-face="back"]') as HTMLElement | null;
+                const rotator = el.querySelector('[data-rotator]') as HTMLElement | null;
+                const prevDisplay = back?.style.display;
+                const prevTransform = rotator?.style.transform;
+                if (back) back.style.display = 'none';
+                if (rotator) rotator.style.transform = 'none';
+                await downloadElementAsJPEG(el, `${title}.jpeg`);
+                if (back) back.style.display = prevDisplay || '';
+                if (rotator) rotator.style.transform = prevTransform || '';
               }}
             >
               Download JPEG

--- a/src/components/widgets/WidgetWrapper.tsx
+++ b/src/components/widgets/WidgetWrapper.tsx
@@ -84,6 +84,7 @@ export const WidgetWrapper = ({ widgetId, title, className }: WidgetWrapperProps
     /* ── Normal flip/card content ── */
     <div className="h-[calc(100%-64px)] relative overflow-hidden perspective-1000">
       <div
+        data-rotator
         className={`absolute inset-0 transition-all duration-600 ease-in-out ${isFlipped ? '[transform:rotateY(180deg)]' : '[transform:rotateY(0deg)]'
           }`}
         style={{ transformStyle: 'preserve-3d' }}
@@ -91,6 +92,7 @@ export const WidgetWrapper = ({ widgetId, title, className }: WidgetWrapperProps
         {/* Front (chart) */}
         <div
           className="absolute inset-0"
+          data-face="front"
           style={{ backfaceVisibility: 'hidden', WebkitBackfaceVisibility: 'hidden' }}
         >
           <div className="p-2 h-full">
@@ -101,6 +103,7 @@ export const WidgetWrapper = ({ widgetId, title, className }: WidgetWrapperProps
         {/* Back (table / SQL) */}
         <div
           className="absolute inset-0"
+          data-face="back"
           style={{
             backfaceVisibility: 'hidden',
             WebkitBackfaceVisibility: 'hidden',


### PR DESCRIPTION
## Summary
- mark the flip container with `data-rotator`
- temporarily disable rotation while exporting front face to PDF/JPEG

## Testing
- `npm run build`
- `npm run lint` *(fails: 11 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688900bc11b48324a4a0fc8bc70021fb